### PR TITLE
Add return tracking attribute to shipments

### DIFF
--- a/lib/fosdick/shipment.rb
+++ b/lib/fosdick/shipment.rb
@@ -5,6 +5,7 @@ module Fosdick
     attribute :fosdick_order_num, String
     attribute :external_order_num, String
     attribute :ship_date, Date
+    attribute :return_tracking, String
     attribute :trackings, Array[Fosdick::Tracking]
 
     def self.all(options = {})


### PR DESCRIPTION
This attribute is required to be able to track returned packages.