### PR TITLE
Strip whitespace from tracking numbers

### DIFF
--- a/lib/fosdick/shipment.rb
+++ b/lib/fosdick/shipment.rb
@@ -11,5 +11,9 @@ module Fosdick
     def self.all(options = {})
       Fosdick::Resource.new(self, "shipments").all(options)
     end
+
+    def return_tracking=(return_tracking)
+      super return_tracking.strip
+    end
   end
 end

--- a/lib/fosdick/shipment.rb
+++ b/lib/fosdick/shipment.rb
@@ -13,7 +13,7 @@ module Fosdick
     end
 
     def return_tracking=(return_tracking)
-      super return_tracking.strip
+      super return_tracking&.strip
     end
   end
 end

--- a/lib/fosdick/tracking.rb
+++ b/lib/fosdick/tracking.rb
@@ -5,5 +5,9 @@ module Fosdick
     attribute :tracking_num, String
     attribute :carrier_code, String
     attribute :carrier_name, String
+
+    def tracking_num=(tracking_num)
+      super tracking_num.strip
+    end
   end
 end

--- a/lib/fosdick/tracking.rb
+++ b/lib/fosdick/tracking.rb
@@ -7,7 +7,7 @@ module Fosdick
     attribute :carrier_name, String
 
     def tracking_num=(tracking_num)
-      super tracking_num.strip
+      super tracking_num&.strip
     end
   end
 end

--- a/spec/fosdick/shipment_spec.rb
+++ b/spec/fosdick/shipment_spec.rb
@@ -1,6 +1,16 @@
 require "spec_helper"
 
 describe Fosdick::Shipment do
+  describe '#return_tracking=' do
+    it "strips whitespace from the return tracking number" do
+      shipment = described_class.new
+
+      shipment.return_tracking = "\tRETURN "
+
+      expect(shipment.return_tracking).to eq("RETURN")
+    end
+  end
+
   describe ".all", :vcr do
     context "given shipped_on_min" do
       it "gets shipments shipped since the timestamp", :vcr do

--- a/spec/fosdick/shipment_spec.rb
+++ b/spec/fosdick/shipment_spec.rb
@@ -9,6 +9,14 @@ describe Fosdick::Shipment do
 
       expect(shipment.return_tracking).to eq("RETURN")
     end
+
+    it "handles nil values" do
+      shipment = described_class.new
+
+      shipment.return_tracking = nil
+
+      expect(shipment.return_tracking).to eq(nil)
+    end
   end
 
   describe ".all", :vcr do

--- a/spec/fosdick/tracking_spec.rb
+++ b/spec/fosdick/tracking_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Fosdick::Tracking do
+  describe '#tracking_num=' do
+    it "strips whitespace from the tracking number" do
+      tracking = described_class.new
+
+      tracking.tracking_num = "\tTRACKING\t"
+
+      expect(tracking.tracking_num).to eq("TRACKING")
+    end
+  end
+end

--- a/spec/fosdick/tracking_spec.rb
+++ b/spec/fosdick/tracking_spec.rb
@@ -9,5 +9,13 @@ describe Fosdick::Tracking do
 
       expect(tracking.tracking_num).to eq("TRACKING")
     end
+
+    it "handles nil values" do
+      tracking = described_class.new
+
+      tracking.tracking_num = nil
+
+      expect(tracking.tracking_num).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
Sometimes Fosdick includes leading and trailing whitespace in its tracking numbers, this is really inconvenient if you're storing this tracking numbers and later trying to search for them, so we'll get rid of the whitespace.