### PR TITLE
Update Faraday dependency version

### DIFF
--- a/fosdick.gemspec
+++ b/fosdick.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.12"
+  spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "patron", "~> 0.5.0"
   spec.add_dependency "virtus", "~> 1.0.5"
 

--- a/fosdick.gemspec
+++ b/fosdick.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9.2"
+  spec.add_dependency "faraday", "~> 0.12"
   spec.add_dependency "patron", "~> 0.5.0"
   spec.add_dependency "virtus", "~> 1.0.5"
 


### PR DESCRIPTION
#### What's this PR do?
We'll update the faraday dependency to allow for minor version updates since they shouldn't introduce backwards-incompatible functionality and make our gem compatible with newer versions of Faraday that may be required by other gems.